### PR TITLE
Update deploy-cert-to-lb

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 1. [Create a dynamic group](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingdynamicgroups.htm#ariaid-title9), e.g. *WebServers*, and assign the instance that where the scripts will run on.
 1. [Create a policy](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingpolicies.htm#ariaid-title6), e.g. *LoadBalancerManagementPolicy*, to allow the dynamic group to create certificates and update load balancer's listeners in the specified compartment. The simplest statement to get started with, is this:
     ```
-    allow dynamic-group WebServers to manage load-balancers in compartment MyCompartment
+    allow dynamic-group WebServers to use load-balancers in compartment MyCompartment
     ```
 
    > **NOTE**

--- a/app/deploy-cert-to-lb
+++ b/app/deploy-cert-to-lb
@@ -14,7 +14,11 @@ if [[ $DRY_RUN =~ [yY] ]]; then
   exit 0
 fi
 
+# Default parameters for oci command
 oci_defaults=()
+# We use dynamic groups authentication
+oci_defaults+=(--auth instance_principal)
+# Load balancer OCID defined in enviroment file
 oci_defaults+=(--load-balancer-id ${LB_OCID})
 
 oci lb certificate create ${oci_defaults[@]} \
@@ -71,20 +75,21 @@ if [ $? -eq 0 ]; then
     params+=(--ssl-verify-depth ${SSL_VERIFY_DEPTH})
     params+=(--ssl-verify-peer-certificate ${SSL_VERIFY_PEER_CERTIFICATE})
     params+=(--ssl-certificate-name ${CERT_NAME})
-    params+=(--cipher-suite-name ${CIPHER_SUITE_NAME});
-    params+=(--protocols ${PROTOCOLS});
-    params+=(--server-order-preference ${SERVER_ORDER_PREFERENCE});
+    params+=(--cipher-suite-name ${CIPHER_SUITE_NAME})
+    params+=(--protocols ${PROTOCOLS})
+    params+=(--server-order-preference ${SERVER_ORDER_PREFERENCE})
     params+=(--force)
     params+=(--wait-for-state SUCCEEDED)
 
     oci lb listener update \
       ${params[@]}
-    
+
     # Delete old certificates if listenet update succeeded
-    if [ $? -eq 0 ]; then
-    
+    # and operation is permitted in enviroment file
+    if [ $? -eq 0 ] && [[ $DEL_OLD_CERTS =~ [yY] ]]; then
+
       # Get existing certificate list for deleting old certificates
-      CERT_LIST=$(oci lb certificate list ${oci_defaults[@]});
+      CERT_LIST=$(oci lb certificate list ${oci_defaults[@]})
 
       # Loop certificate names that start with domain name
       echo ${CERT_LIST} | jq -rc --arg cert_prefix ${LE_CERT_NAME} \

--- a/app/deploy-cert-to-lb
+++ b/app/deploy-cert-to-lb
@@ -47,6 +47,13 @@ if [ $? -eq 0 ]; then
       '.data.listeners[$listener_name]."ssl-configuration"."verify-depth"')
     SSL_VERIFY_PEER_CERTIFICATE=$(echo $LB_DATA | jq -rc --arg listener_name "$LISTENER_NAME" \
       '.data.listeners[$listener_name]."ssl-configuration"."verify-peer-certificate"')
+      
+    CIPHER_SUITE_NAME=$(echo $LB_DATA | jq -rc --arg listener_name "${LISTENER_NAME}" \
+      '.data.listeners[$listener_name]."ssl-configuration"."cipher-suite-name"')
+    PROTOCOLS=$(echo $LB_DATA | jq -rc --arg listener_name "${LISTENER_NAME}" \
+      '.data.listeners[$listener_name]."ssl-configuration"."protocols"')
+    SERVER_ORDER_PREFERENCE=$(echo $LB_DATA | jq -rc --arg listener_name "${LISTENER_NAME}" \
+      '.data.listeners[$listener_name]."ssl-configuration"."server-order-preference"')
 
     params=()
     params+=(--load-balancer-id ${LB_OCID})
@@ -64,11 +71,16 @@ if [ $? -eq 0 ]; then
     params+=(--ssl-verify-depth ${SSL_VERIFY_DEPTH})
     params+=(--ssl-verify-peer-certificate ${SSL_VERIFY_PEER_CERTIFICATE})
     params+=(--ssl-certificate-name ${CERT_NAME})
+
+    params+=(--cipher-suite-name ${CIPHER_SUITE_NAME});
+    params+=(--protocols ${PROTOCOLS});
+    params+=(--server-order-preference ${SERVER_ORDER_PREFERENCE});
+
     params+=(--force)
     params+=(--wait-for-state SUCCEEDED)
 
     oci lb listener update \
-      ${params[@]}
+      ${params[@]}    
   else
     echo "Please remember to create the HTTPS listener and assign the certificate $CERT_NAME manually."
   fi

--- a/app/deploy-cert-to-lb
+++ b/app/deploy-cert-to-lb
@@ -14,7 +14,10 @@ if [[ $DRY_RUN =~ [yY] ]]; then
   exit 0
 fi
 
-oci lb certificate create --load-balancer-id ${LB_OCID} \
+oci_defaults=()
+oci_defaults+=(--load-balancer-id ${LB_OCID})
+
+oci lb certificate create ${oci_defaults[@]} \
   --certificate-name ${CERT_NAME} \
   --private-key-file ${CERT_PATH}/privkey.pem \
   --public-certificate-file ${CERT_PATH}/fullchain.pem \
@@ -24,7 +27,7 @@ if [ $? -eq 0 ]; then
   echo "Successfully created certificate."
 
   if [ ! -z "$LISTENER_NAME" ]; then
-    LB_DATA=$(oci lb load-balancer get --load-balancer-id $LB_OCID)
+    LB_DATA=$(oci lb load-balancer get ${oci_defaults[@]})
 
     DEFAULT_BACKEND_SET=$(echo $LB_DATA | jq -r --arg listener_name "$LISTENER_NAME" \
       '.data.listeners[$listener_name]."default-backend-set-name"')
@@ -54,7 +57,7 @@ if [ $? -eq 0 ]; then
       '.data.listeners[$listener_name]."ssl-configuration"."server-order-preference"')
 
     params=()
-    params+=(--load-balancer-id ${LB_OCID})
+    params+=${oci_defaults[@]}
     params+=(--default-backend-set-name ${DEFAULT_BACKEND_SET})
     if [[ $BACKEND_TCP_PROXY_PROTOCOL_VERSION =~ '^[0-9]+$' ]]; then
       params+=(--connection-configuration-backend-tcp-proxy-protocol-version ${BACKEND_TCP_PROXY_PROTOCOL_VERSION})
@@ -82,7 +85,7 @@ if [ $? -eq 0 ]; then
     if [ $? -eq 0 ]; then
     
       # Get existing certificate list for deleting old certificates
-      CERT_LIST=$(oci lb certificate list --load-balancer-id ${LB_OCID});
+      CERT_LIST=$(oci lb certificate list ${oci_defaults[@]});
 
       # Loop certificate names that start with domain name
       echo ${CERT_LIST} | jq -rc --arg cert_prefix ${LE_CERT_NAME} \
@@ -92,7 +95,7 @@ if [ $? -eq 0 ]; then
         # Delete certificate if certificate name is not same that just uploaded
         # Note! deletion will fail if certificate is used in listener or backend set
         if [[ "${CERT_NAME}" != "${CERT_OLD}" ]]; then
-          oci lb certificate delete --load-balancer-id ${LB_OCID} \
+          oci lb certificate delete ${oci_defaults[@]} \
             --certificate-name "${CERT_OLD}" \
             --force
         fi

--- a/app/deploy-cert-to-lb
+++ b/app/deploy-cert-to-lb
@@ -56,8 +56,7 @@ if [ $? -eq 0 ]; then
     SERVER_ORDER_PREFERENCE=$(echo $LB_DATA | jq -rc --arg listener_name "${LISTENER_NAME}" \
       '.data.listeners[$listener_name]."ssl-configuration"."server-order-preference"')
 
-    params=()
-    params+=${oci_defaults[@]}
+    params=(${oci_defaults[@]})
     params+=(--default-backend-set-name ${DEFAULT_BACKEND_SET})
     if [[ $BACKEND_TCP_PROXY_PROTOCOL_VERSION =~ '^[0-9]+$' ]]; then
       params+=(--connection-configuration-backend-tcp-proxy-protocol-version ${BACKEND_TCP_PROXY_PROTOCOL_VERSION})

--- a/app/deploy-cert-to-lb
+++ b/app/deploy-cert-to-lb
@@ -47,7 +47,6 @@ if [ $? -eq 0 ]; then
       '.data.listeners[$listener_name]."ssl-configuration"."verify-depth"')
     SSL_VERIFY_PEER_CERTIFICATE=$(echo $LB_DATA | jq -rc --arg listener_name "$LISTENER_NAME" \
       '.data.listeners[$listener_name]."ssl-configuration"."verify-peer-certificate"')
-      
     CIPHER_SUITE_NAME=$(echo $LB_DATA | jq -rc --arg listener_name "${LISTENER_NAME}" \
       '.data.listeners[$listener_name]."ssl-configuration"."cipher-suite-name"')
     PROTOCOLS=$(echo $LB_DATA | jq -rc --arg listener_name "${LISTENER_NAME}" \
@@ -71,16 +70,35 @@ if [ $? -eq 0 ]; then
     params+=(--ssl-verify-depth ${SSL_VERIFY_DEPTH})
     params+=(--ssl-verify-peer-certificate ${SSL_VERIFY_PEER_CERTIFICATE})
     params+=(--ssl-certificate-name ${CERT_NAME})
-
     params+=(--cipher-suite-name ${CIPHER_SUITE_NAME});
     params+=(--protocols ${PROTOCOLS});
     params+=(--server-order-preference ${SERVER_ORDER_PREFERENCE});
-
     params+=(--force)
     params+=(--wait-for-state SUCCEEDED)
 
     oci lb listener update \
-      ${params[@]}    
+      ${params[@]}
+    
+    # Delete old certificates if listenet update succeeded
+    if [ $? -eq 0 ]; then
+    
+      # Get existing certificate list for deleting old certificates
+      CERT_LIST=$(oci lb certificate list --load-balancer-id ${LB_OCID});
+
+      # Loop certificate names that start with domain name
+      echo ${CERT_LIST} | jq -rc --arg cert_prefix ${LE_CERT_NAME} \
+        '.data[]."certificate-name" | select(startswith($cert_prefix))' \
+      | while IFS= read -r CERT_OLD;
+      do
+        # Delete certificate if certificate name is not same that just uploaded
+        # Note! deletion will fail if certificate is used in listener or backend set
+        if [[ "${CERT_NAME}" != "${CERT_OLD}" ]]; then
+          oci lb certificate delete --load-balancer-id ${LB_OCID} \
+            --certificate-name "${CERT_OLD}" \
+            --force
+        fi
+      done
+    fi
   else
     echo "Please remember to create the HTTPS listener and assign the certificate $CERT_NAME manually."
   fi

--- a/app/deploy-cert-to-lb
+++ b/app/deploy-cert-to-lb
@@ -16,9 +16,8 @@ fi
 
 oci lb certificate create --load-balancer-id ${LB_OCID} \
   --certificate-name ${CERT_NAME} \
-  --ca-certificate-file ${CERT_PATH}/chain.pem \
   --private-key-file ${CERT_PATH}/privkey.pem \
-  --public-certificate-file ${CERT_PATH}/cert.pem \
+  --public-certificate-file ${CERT_PATH}/fullchain.pem \
   --wait-for-state SUCCEEDED
 
 if [ $? -eq 0 ]; then

--- a/domain.env.sample
+++ b/domain.env.sample
@@ -3,4 +3,5 @@ EMAIL=johndoe@example.com
 DEPLOY_TARGET=LB
 LB_OCID=ocid1.loadbalancer.oc1...
 LISTENER_NAME=listener_https
+DEL_OLD_CERTS=N
 DRY_RUN=Y


### PR DESCRIPTION
Include listener new attributes cipher-suite-name, protocols and server-order-preference. Delete old certificates. Removed CA file and use fullchain.pem as public certificate file prevents ssllabs.com complaining about certificate order.